### PR TITLE
Don't sanitize URLs in order to preserve addresses for papers

### DIFF
--- a/bib2tpl/bibtex_converter.php
+++ b/bib2tpl/bibtex_converter.php
@@ -459,7 +459,8 @@ class BibtexConverter {
         $value = $entry['niceauthor'];
         $value = $this->authorlink($value);
       }
-      if ( $key == 'bibtex') {
+      // Don't sanitize values associated with bibtex or url keys 
+      if ( $key == 'bibtex' || $key == 'url') {
         $patterns []= '/@'.$key.'@/';
         $replacements []= $value;
       }


### PR DESCRIPTION
Minor change to not sanitize web addresses, this is primarily to preserve tildes in URLs.